### PR TITLE
Fix memleak in vector_realloc.

### DIFF
--- a/util/vector.c
+++ b/util/vector.c
@@ -47,6 +47,7 @@ int vector_realloc(struct vector *v, int capacity)
 
 		v->ptr = new_ptr;
 	} else {
+		free(v->ptr);
 		v->ptr = NULL;
 	}
 


### PR DESCRIPTION
When calling vector_realloc with a new capacity of 0 (as does cmd_help) the vector pointer will be set to NULL without freeing the memory it points to.