### PR TITLE
ui/devcmd.c: fix path in error text

### DIFF
--- a/ui/devcmd.c
+++ b/ui/devcmd.c
@@ -646,7 +646,7 @@ static int do_cmd_prog(char **arg, int prog_flags)
 	in = fopen(path, "rb");
 	free(path);
 	if (!in) {
-		printc_err("prog: %s: %s\n", *arg, last_error());
+		printc_err("prog: %s: %s\n", path, last_error());
 		return -1;
 	}
 


### PR DESCRIPTION
This patch fixes the issue that if the path argument of a prog/verify command can't be opened then the path is not included in the error message. Actually the second argument is shown instead the first.

e.g.
(mspdebug) prog foo
prog: : No such file or directory
(mspdebug) prog foo bar
prog: bar: No such file or directory
(mspdebug) 

This issue is a side effect on calling get_arg(arg) that internally modifies arg.
