### PR TITLE
ui/devcmd.c: move free(path) after usage

### DIFF
--- a/drivers/goodfet.c
+++ b/drivers/goodfet.c
@@ -528,6 +528,7 @@ static device_t goodfet_open(const struct device_args *args)
 		return NULL;
 	}
 
+        memset(gc, 0, sizeof(*gc));
 	gc->base.type = &device_goodfet;
 	gc->base.max_breakpoints = 0;
 	gc->base.need_probe = 1;

--- a/ui/devcmd.c
+++ b/ui/devcmd.c
@@ -644,11 +644,12 @@ static int do_cmd_prog(char **arg, int prog_flags)
 		return -1;
 
 	in = fopen(path, "rb");
-	free(path);
 	if (!in) {
 		printc_err("prog: %s: %s\n", path, last_error());
+                free(path);
 		return -1;
 	}
+	free(path);
 
 	if (device_ctl(DEVICE_CTL_HALT) < 0) {
 		fclose(in);


### PR DESCRIPTION
Fix for #11: path was free'd too early.
