### PR TITLE
Makefile: Fix Cygwin build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ BINDIR = ${PREFIX}/bin/
 MANDIR = ${PREFIX}/share/man/man1
 LIBDIR = ${PREFIX}/lib/
 
+UNAME_S := $(shell sh -c 'uname -s')
+UNAME_O := $(shell sh -c 'uname -o 2> /dev/null')
+
 ifdef WITHOUT_READLINE
 	READLINE_CFLAGS =
 	READLINE_LIBS =
@@ -38,17 +41,15 @@ endif
 ifeq ($(OS),Windows_NT)
     MSPDEBUG_CC = $(CC)
     BINARY = mspdebug.exe
-
     ifneq ($(UNAME_O),Cygwin)
 	OS_LIBS = -lws2_32 -lregex
 	OS_CFLAGS = -D__Windows__ -DNO_SHELLCMD
+	RM = del
     endif
 else
     MSPDEBUG_CC = $(CC)
     BINARY = mspdebug
 
-    UNAME_S := $(shell sh -c 'uname -s')
-    UNAME_O := $(shell sh -c 'uname -o 2> /dev/null')
 
     ifneq ($(filter $(UNAME_S),OpenBSD NetBSD),)
 	OS_LIBS =
@@ -92,17 +93,22 @@ all: $(BINARY)
 
 ifeq ($(OS),Windows_NT)
 clean:
-	del drivers\*.o
-	del formats\*.o
-	del simio\*.o
-	del transport\*.o
-	del ui\*.o
-	del util\*.o
-	del $(BINARY)
+    ifeq ($(UNAME_O),Cygwin)
+	$(RM) */*.o
+	$(RM) $(BINARY)
+    else
+	$(RM) drivers\*.o
+	$(RM) formats\*.o
+	$(RM) simio\*.o
+	$(RM) transport\*.o
+	$(RM) ui\*.o
+	$(RM) util\*.o
+	$(RM) $(BINARY)
+    endif
 else
 clean:
-	rm -f */*.o
-	rm -f $(BINARY)
+	$(RM) */*.o
+	$(RM) $(BINARY)
 endif
 
 install: $(BINARY) mspdebug.man


### PR DESCRIPTION
This commit moves the definitions of UNAME_* above the initial check
of the OS environment variable. Previously, UNAME_O would not be set
in the case where OS is Windows_NT. Builds would incorrectly use Windows
OS_LIBS and OS_CFLAGS in a Cygwin build environment. The tree now builds
cleanly with Cygwin's libusb-1.0 and libreadline development packages
installed.

Using Cygwin's serial port mappings for MSP-FET430UIF:

$ mspdebug -d /dev/ttyS1 uif

MSPDebug version 0.24 - debugging tool for MSP430 MCUs
Copyright (C) 2009-2016 Daniel Beer <dlbeer@gmail.com>
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Chip info database from MSP430.dll v3.3.1.4 Copyright (C) 2013 TI, Inc.

Trying to open /dev/ttyS1 at 460800 bps...
Initializing FET...
FET protocol version is 20408002
Set Vcc: 3000 mV
Configured for Spy-Bi-Wire
Device ID: 0x0580
  Code start address: 0x5c00
  Code size         : 262144 byte = 256 kb
  RAM  start address: 0x1c00
  RAM  end   address: 0x5bff
  RAM  size         : 16384 byte = 16 kb
Device: MSP430F5438A
Number of breakpoints: 8
fet: FET returned NAK
warning: device does not support power profiling
Chip ID data:
  ver_id:         8005
  ver_sub_id:     0000
  revision:       13
  fab:            55
  self:           5555
  config:         13
Device: MSP430F5438A

[...]