### PR TITLE
Add support for reset and test pins via gpio driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 CC ?= gcc
 INSTALL = /usr/bin/install
 PREFIX ?= /usr/local
-LDFLAGS ?= -s
+# LDFLAGS ?= -s
 
 BINDIR = ${PREFIX}/bin/
 MANDIR = ${PREFIX}/share/man/man1

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 CC ?= gcc
 INSTALL = /usr/bin/install
 PREFIX ?= /usr/local
-# LDFLAGS ?= -s
+LDFLAGS ?= -s
 
 BINDIR = ${PREFIX}/bin/
 MANDIR = ${PREFIX}/share/man/man1

--- a/drivers/jtdev_gpio.c
+++ b/drivers/jtdev_gpio.c
@@ -42,11 +42,13 @@ enum {
     GPIO_TCK,
     GPIO_TMS,
     GPIO_TDO,
+    GPIO_RST,
+    GPIO_TST,
     GPIO_REQUIRED
 };
 
-unsigned int jtag_gpios[4];
-int          fd_gpios[4];
+unsigned int jtag_gpios[6];
+int          fd_gpios[6];
 
 static int
 gpio_open ()
@@ -87,15 +89,17 @@ gpio_parse_config (const char *params)
       {"tms=",GPIO_TMS},
       {"tdi=",GPIO_TDI},
       {"tdo=",GPIO_TDO},
-      {"tck=",GPIO_TCK}
+      {"tck=",GPIO_TCK},
+      {"rst=",GPIO_RST},
+      {"tst=",GPIO_TST}
     };
     int i;
 
-    for( i = 0;i < 4; i++) {
+    for( i = 0;i < 6; i++) {
       char* help;
       help = strstr(params,ops[i].name);
       if (help)
-        jtag_gpios[ops[i].num] = atoi(help+4);
+        jtag_gpios[ops[i].num] = atoi(help+6);
       else
 	return -1;
       printf("gpio %s %d\n", ops[i].name,jtag_gpios[ops[i].num]);
@@ -164,12 +168,12 @@ static void jtgpio_tdi(struct jtdev *p, int out)
 
 static void jtgpio_rst(struct jtdev *p, int out)
 {
-  printf("jtag_reset\n");
+  gpio_set_value_fd (fd_gpios[GPIO_RST], out);
 }
 
 static void jtgpio_tst(struct jtdev *p, int out)
 {
-  printf("jtag_test\n");
+  gpio_set_value_fd (fd_gpios[GPIO_TST], out);
 }
 
 static int jtgpio_tdo_get(struct jtdev *p)

--- a/drivers/jtdev_gpio.c
+++ b/drivers/jtdev_gpio.c
@@ -99,7 +99,7 @@ gpio_parse_config (const char *params)
       char* help;
       help = strstr(params,ops[i].name);
       if (help)
-        jtag_gpios[ops[i].num] = atoi(help+6);
+        jtag_gpios[ops[i].num] = atoi(help+4);
       else
 	return -1;
       printf("gpio %s %d\n", ops[i].name,jtag_gpios[ops[i].num]);

--- a/mspdebug.man
+++ b/mspdebug.man
@@ -203,7 +203,7 @@ Linux, ppi on FreeBSD and DragonFly BSD) must be specified via the
 Connect to system gpios. JTAG mode must be used, and
 only tty access is supported. Currently, this driver is only supported
 on Linux, FreeBSD and DragonFly BSD. The gpios to used must defined using
-a string like "tdi=7 tdo=8 tms=9 tck=4" via the
+a string like "tdi=7 tdo=8 tms=9 tck=4 rst=10 tst=11" via the
 \fB-d\fR option. (dont forget the quotes)
 
 .IP "\fBload-bsl\fR"


### PR DESCRIPTION
The gpio driver is updated to take 6 gpio pin assignments to support 4-wire JTAG with reset and test pins.  This has been tested with a Raspberry Pi Zero, Debian Jessie, and an Olimex MSP430-449STK-B.  Example command line: 

`sudo ./mspdebug -j -d "tdi=3 tdo=2 tms=4 tck=17 rst=22 tst=27" gpio`