### PR TITLE
Toggle test and reset pins to make gpio 4-wire JTAG work on SBW-enabled targets

### DIFF
--- a/drivers/jtaglib.c
+++ b/drivers/jtaglib.c
@@ -386,12 +386,20 @@ unsigned int jtag_init(struct jtdev *p)
 
 	jtag_rst_clr(p);
 	p->f->jtdev_power_on(p);
-	jtag_tst_set(p);
 	jtag_tdi_set(p);
 	jtag_tms_set(p);
 	jtag_tck_set(p);
 	jtag_tclk_set(p);
+
+	jtag_rst_set(p);
+	jtag_tst_clr(p);
+
+	jtag_tst_set(p);
 	jtag_rst_clr(p);
+	jtag_tst_clr(p);
+
+	jtag_tst_set(p);
+
 	p->f->jtdev_connect(p);
 	jtag_rst_set(p);
 	jtag_reset_tap(p);


### PR DESCRIPTION
Without this patch, a newer SBW-enabled target would not enter 4-wire JTAG mode.  After applying the patch, using the gpio driver on a Raspberry Pi Zero, 4-wire JTAG mode worked with either an MSP430F449 and an MSPG2452.  