### PR TITLE
drivers/jtdev_bus_pirate: Fix GCC 7 misleading indent warning

### DIFF
--- a/drivers/jtdev_bus_pirate.c
+++ b/drivers/jtdev_bus_pirate.c
@@ -182,11 +182,11 @@ static int jtbp_open(struct jtdev *p, const char *device)
 
 static void jtbp_close(struct jtdev *p)
 {
-    char out_buff;
+	char out_buff;
 
-    out_buff = 0x0f;
-    // Don't care if this fails, user can just power cycle the bus pirate
-    if(write(p->port, &out_buff, 1));
+	out_buff = 0x0f;
+	// Don't care if this fails, user can just power cycle the bus pirate
+	if(write(p->port, &out_buff, 1));
 
 	close(p->port);
 }


### PR DESCRIPTION
Indent the jtbp_close() function consistently with tabs in order to fix
for GCC 7's flagging of this warning:

drivers/jtdev_bus_pirate.c: In function ‘jtbp_close’:
drivers/jtdev_bus_pirate.c:189:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if(write(p->port, &out_buff, 1));
     ^~
drivers/jtdev_bus_pirate.c:191:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  close(p->port);
  ^~~~~

Signed-off-by: Andrew Bradford <andrew@bradfordembedded.com>