### PR TITLE
Fix MinGW compilation under Windows.

### DIFF
--- a/util/sockets.c
+++ b/util/sockets.c
@@ -30,6 +30,7 @@
 
 #ifdef __Windows__
 #include <windows.h>
+#include <winerror.h>
 #endif
 
 #ifdef __Windows__


### PR DESCRIPTION
Compilation using MinGW under Windows 7 (using the instructions on the site) was failing due to a missing header:

C:\mspdebug>make CC=mingw32-gcc
mingw32-gcc  -DUSE_READLINE  -O1 -Wall -Wno-char-subscripts -ggdb -I. -Isimio -Iformats -Itransport -Idrivers -Iutil -Iui -DLIB_DIR=\"/usr/local/lib/\" -D__Windows__ -DNO_SHELLCMD -o util/btree.o -c util/btree.c
mingw32-gcc  -DUSE_READLINE  -O1 -Wall -Wno-char-subscripts -ggdb -I. -Isimio -Iformats -Itransport -Idrivers -Iutil -Iui -DLIB_DIR=\"/usr/local/lib/\" -D__Windows__ -DNO_SHELLCMD -o util/expr.o -c util/expr.c
mingw32-gcc  -DUSE_READLINE  -O1 -Wall -Wno-char-subscripts -ggdb -I. -Isimio -Iformats -Itransport -Idrivers -Iutil -Iui -DLIB_DIR=\"/usr/local/lib/\" -D__Windows__ -DNO_SHELLCMD -o util/list.o -c util/list.c
mingw32-gcc  -DUSE_READLINE  -O1 -Wall -Wno-char-subscripts -ggdb -I. -Isimio -Iformats -Itransport -Idrivers -Iutil -Iui -DLIB_DIR=\"/usr/local/lib/\" -D__Windows__ -DNO_SHELLCMD -o util/sockets.o -c util/sockets.c
util/sockets.c: In function 'sockets_wait':
util/sockets.c:57:16: error: 'ERROR_OPERATION_ABORTED' undeclared (first use inthis function)
   error_save = ERROR_OPERATION_ABORTED;
                ^~~~~~~~~~~~~~~~~~~~~~~
util/sockets.c:57:16: note: each undeclared identifier is reported only once for each function it appears in
make: *** [util/sockets.o] Error 1
