### PR TITLE
Fallback to libusb backend when rf2500hidapi fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ else
 	PORTS_LDFLAGS := -L/opt/local/lib -lhidapi -framework IOKit -framework CoreFoundation
       endif
       BSLHID_OBJ = transport/bslosx.o
-      RF25000_OBJ = transport/rf2500hidapi.o
+      RF25000_OBJ += transport/rf2500hidapi.o
       LDFLAGS =
     else ifneq ($(filter $(UNAME_S),OpenBSD NetBSD DragonFly),)
 	PORTS_CFLAGS := $(shell pkg-config --cflags libusb)

--- a/transport/rf2500.c
+++ b/transport/rf2500.c
@@ -228,7 +228,7 @@ static const struct transport_class rf2500_transport = {
 	.set_modem	= usbtr_set_modem
 };
 
-transport_t rf2500_open(const char *devpath, const char *requested_serial)
+transport_t rf2500_libusb_open(const char *devpath, const char *requested_serial)
 {
 	struct rf2500_transport *tr = malloc(sizeof(*tr));
 	struct usb_device *dev;

--- a/transport/rf2500.h
+++ b/transport/rf2500.h
@@ -28,5 +28,6 @@
  * A particular device may be specified in bus:dev form.
  */
 transport_t rf2500_open(const char *dev_path, const char *requested_serial);
+transport_t rf2500_libusb_open(const char *dev_path, const char *requested_serial);
 
 #endif

--- a/transport/rf2500hidapi.c
+++ b/transport/rf2500hidapi.c
@@ -196,7 +196,8 @@ transport_t rf2500_open(const char *devpath, const char *requested_serial)
 		printc_err("rf2500: failed to open RF2500 device\n");
 		free(tr);
 		hid_exit();
-		return NULL;
+		printc_err("rf2500: fallback to libusb backend\n");
+		return rf2500_libusb_open(devpath, requested_serial);
 	}
 
 	tr->handle = handle;


### PR DESCRIPTION
In some macOS configurations, macOS 10.13.5 on Macmini4,1 in my case,
rf2500hidapi transport fails to open RF2500 device with unknown
reason. This CL enables mspdebug to fallback to libusb backend in such
situation.