### PR TITLE
Fix repeated disassemble

### DIFF
--- a/ui/devcmd.c
+++ b/ui/devcmd.c
@@ -399,7 +399,9 @@ int cmd_dis(char **arg)
 				len_text);
 			return -1;
 		}
-	} else if (offset < 0x10000 && offset + length > 0x10000) {
+	}
+	length += (length & 1);
+	if (offset < 0x10000 && offset + length > 0x10000) {
 		length = 0x10000 - offset;
 	}
 
@@ -414,8 +416,8 @@ int cmd_dis(char **arg)
 		return -1;
 	}
 
-	reader_set_repeat("dis 0x%x 0x%x", offset + length, length);
-	disassemble(offset, buf, length, device_default->power_buf);
+	offset = disassemble(offset, buf, length, device_default->power_buf);
+	reader_set_repeat("dis 0x%x 0x%x", offset, length);
 	free(buf);
 	return 0;
 }

--- a/util/output_util.c
+++ b/util/output_util.c
@@ -205,12 +205,13 @@ static int dis_format(const struct msp430_instruction *insn)
 	return len;
 }
 
-void disassemble(address_t offset, const uint8_t *data, int length,
+address_t disassemble(address_t offset, const uint8_t *data, int length,
 		 powerbuf_t power)
 {
 	int first_line = 1;
 	unsigned long long ua_total = 0;
 	int samples_total = 0;
+	address_t next_offset = offset;
 
 	while (length) {
 		struct msp430_instruction insn = {0};
@@ -231,6 +232,8 @@ void disassemble(address_t offset, const uint8_t *data, int length,
 		first_line = 0;
 
 		retval = dis_decode(data, offset, length, &insn);
+		if (retval > 0)
+			next_offset = offset + retval;
 		count = retval > 0 ? retval : 2;
 		if (count > length)
 			count = length;
@@ -279,6 +282,8 @@ void disassemble(address_t offset, const uint8_t *data, int length,
 		       (double)(ua_total * power->interval_us) / 1000000.0,
 		       (double)(samples_total * power->interval_us) / 1000.0,
 		       (double)ua_total / (double)samples_total);
+
+	return next_offset;
 }
 
 void hexdump(address_t addr, const uint8_t *data, int data_len)

--- a/util/output_util.h
+++ b/util/output_util.h
@@ -23,8 +23,11 @@
 #include "util.h"
 #include "powerbuf.h"
 
-/* Print colorized disassembly on command processor standard output */
-void disassemble(address_t addr, const uint8_t *buf, int len,
+/* Print colorized disassembly on command processor standard output.
+ *
+ * Returns the next possible instruction address.
+ */
+address_t disassemble(address_t addr, const uint8_t *buf, int len,
 		 powerbuf_t power);
 
 /* Print colorized hexdump on standard output */


### PR DESCRIPTION
- An odd disassemble length is rounded up to the next even length.
- A repeated disassemble starts from the next possible instrunction address.

This fixes [issue#70](https://github.com/dlbeer/mspdebug/issues/70).