### PR TITLE
Detect macports to find hidapi and libusb.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ else
       else ifeq ($(shell brew --version > /dev/null 2>&1 && echo ok),ok)
 	PORTS_CFLAGS := $(shell pkg-config --cflags hidapi libusb)
 	PORTS_LDFLAGS := $(shell pkg-config --libs hidapi libusb) -framework IOKit -framework CoreFoundation
+      else ifeq ($(shell port version > /dev/null 2>&1 && echo ok),ok)
+	PORTS_CFLAGS := $(shell pkg-config --cflags hidapi libusb)
+	PORTS_LDFLAGS := $(shell pkg-config --libs hidapi libusb) -framework IOKit -framework CoreFoundation
       else
 	PORTS_CFLAGS := -I/opt/local/include
 	PORTS_LDFLAGS := -L/opt/local/lib -lhidapi -framework IOKit -framework CoreFoundation


### PR DESCRIPTION
Hi,
I am using Macports and with these changes it compiles cleanly (hidapi includes are in /opt/local/include/hidapi so the default clause doesn't work).
