### PR TITLE
Facelift MSPDEBUG_TILIB_PATH handling

### DIFF
--- a/drivers/tilib_api.c
+++ b/drivers/tilib_api.c
@@ -18,6 +18,7 @@
 
 #include <limits.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "util/output.h"
@@ -760,18 +761,21 @@ static int init_old_api(void)
 
 int tilib_api_init(void)
 {
-	int ret;
+	int ret, res;
 	char libpath[PATH_MAX], *path;
 
 	libpath[0] = '\0';
 	if ((path = getenv("MSPDEBUG_TILIB_PATH")) != NULL) {
-		if (strlen(path) + strlen(tilib_filename) + 2 < PATH_MAX) {
-			strcat(libpath, path);
-			strcat(libpath, "/");
-		} else
-			printc_err("Contents of MSP430_PATH variable are too long, ignoring\n");
+		res = snprintf(libpath, sizeof(libpath), "%s/%s", path, tilib_filename);
+	} else {
+		res = snprintf(libpath, sizeof(libpath), "%s", tilib_filename);
 	}
-	strcat(libpath, tilib_filename);
+
+	if(res == -1 || res >= sizeof(libpath)) {
+		printc_err("MSPDEBUG_TILIB_PATH specifies too long a path\n");
+
+		return -1;
+	}
 
 	lib_handle = dynload_open(libpath);
 


### PR DESCRIPTION
Yes, I primarily just want to get rid of strcat (which is checked and
appears to be OK, but still, it's 2018).

Also bring behaviour in line with manual and common expectations:

- In absence of MSPDEBUG_TILIB_PATH, the dynamic linker search
  path is processed
- If MSPDEBUG_TILIB_PATH is specified, that directory is searched
- The original behaviour in case of an error is graceful fall-through
  to letting the dynamic linker do its deed
- The behaviour is changed such that if MSPDEBUG_TILIB_PATH is specified,
  only that path is being considered.

This is in line with both manual and common sense (otherwise one
could have just used LD_LIBRARY_PATH).

Poke @DanielO