### PR TITLE
Improve compiling experience on MinGW platform.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,11 @@ ifeq ($(OS),Windows_NT)
 	OS_CFLAGS = -D__Windows__ -DNO_SHELLCMD
 	RM = del
     endif
+	ifneq (, $findstring(MINGW, $(UNAME_S)))
+		PORTS_CFLAGS := $(shell pkg-config --cflags libusb)
+		PORTS_LDFLAGS := $(shell pkg-config --libs libusb)
+		RM = rm -rf
+	endif
 else
     MSPDEBUG_CC = $(CC)
     BINARY = mspdebug
@@ -105,10 +110,13 @@ all: $(BINARY)
 
 ifeq ($(OS),Windows_NT)
 clean:
-    ifeq ($(UNAME_O),Cygwin)
+ifeq ($(UNAME_O),Cygwin)
 	$(RM) */*.o
 	$(RM) $(BINARY)
-    else
+else ifneq (, $findstring(MINGW, $(UNAME_S)))
+	$(RM) */*.o
+	$(RM) $(BINARY)
+else
 	$(RM) drivers\*.o
 	$(RM) formats\*.o
 	$(RM) simio\*.o
@@ -116,7 +124,7 @@ clean:
 	$(RM) ui\*.o
 	$(RM) util\*.o
 	$(RM) $(BINARY)
-    endif
+endif
 else
 clean:
 	$(RM) */*.o

--- a/transport/bslhid.c
+++ b/transport/bslhid.c
@@ -16,7 +16,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef __Windows__
+#if !defined(__Windows__) || defined(__MINGW32__)
 #include <usb.h>
 #else
 #include <lusb0_usb.h>

--- a/transport/cdc_acm.c
+++ b/transport/cdc_acm.c
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef __Windows__
+#if !defined(__Windows__) || defined(__MINGW32__)
 #include <usb.h>
 #else
 #include <lusb0_usb.h>

--- a/transport/cp210x.c
+++ b/transport/cp210x.c
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef __Windows__
+#if !defined(__Windows__) || defined(__MINGW32__)
 #include <usb.h>
 #else
 #include <lusb0_usb.h>

--- a/transport/rf2500.c
+++ b/transport/rf2500.c
@@ -19,7 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifndef __Windows__
+#if !defined(__Windows__) || defined(__MINGW32__)
 #include <usb.h>
 #else
 #include <lusb0_usb.h>

--- a/transport/ti3410.c
+++ b/transport/ti3410.c
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#ifndef __Windows__
+#if !defined(__Windows__) || defined(__MINGW32__)
 #include <usb.h>
 #else
 #include <lusb0_usb.h>

--- a/util/usbutil.h
+++ b/util/usbutil.h
@@ -19,7 +19,7 @@
 #ifndef USBUTIL_H_
 #define USBUTIL_H_
 
-#ifndef __Windows__
+#if !defined(__Windows__) || defined(__MINGW32__)
 #include <usb.h>
 #else
 #include <lusb0_usb.h>


### PR DESCRIPTION
This PR updates the source and Makefile to support MinGW/Msys2 compilation more naturally. In particular:

* Use `pkg-config` on Windows if the Makefile detects we are using Msys/MinGW.
* Use `usb.h` if MinGW is detected, as is standard on *nix systems.

Been sitting on this PR for a while now (since June 2017) in a private branch, but only now (after some improvements have been made to the Makefile :)...) I've remembered to prepare it :D!