### PR TITLE
Increase limit on number of ELF program / section headers

### DIFF
--- a/formats/elf32.c
+++ b/formats/elf32.c
@@ -32,8 +32,8 @@ static const uint8_t elf32_id[] = {
 	ELFMAG0, ELFMAG1, ELFMAG2, ELFMAG3, ELFCLASS32
 };
 
-#define MAX_PHDRS	32
-#define MAX_SHDRS	128
+#define MAX_PHDRS	128
+#define MAX_SHDRS	512
 
 struct elf32_info {
 	Elf32_Ehdr              file_ehdr;


### PR DESCRIPTION
When defining a greater number of interrupts (~ > 26) in your program and compiling with TI's own mspgcc toolchain, the command "prog x.elf" fails with "elf32: too many program headers".
Apparently, each interrupt gets their very own 2 bytes long section so that you will exceed the hard coded Limit of 32 program headers.
I have increased these hard-coded limits slightly.