### PR TITLE
Add uninstall phony target for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,10 @@ install: $(BINARY) mspdebug.man
 	$(INSTALL) -m 0644 ti_3410.fw.ihex \
 		$(DESTDIR)$(LIBDIR)/mspdebug/ti_3410.fw.ihex
 
+uninstall:
+	$(RM) $(DESTDIR)$(BINDIR)$(BINARY) $(DESTDIR)$(MANDIR)/mspdebug.1\
+ $(DESTDIR)$(LIBDIR)/mspdebug/ti_3410.fw.ihex
+
 .SUFFIXES: .c .o
 
 OBJ=\


### PR DESCRIPTION
Makefile of portable software packages usually provide _uninstall_ phony target for uninstall operations. It's very useful for users if they want to change install path or remove previous versions. 