### PR TITLE
Add docker images thorugh github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+on: [push, pull_request]
+
+jobs:
+  armv7_job:
+    # The host should always be Linux
+    runs-on: ubuntu-18.04
+    name: Build on ubuntu-18.04 armv7
+    steps:
+      - uses: actions/checkout@v2.1.0
+      - uses: uraimo/run-on-arch-action@v2.0.5
+        name: Run commands
+        id: runcmd
+        with:
+          arch: armv7
+          distro: ubuntu18.04
+
+          # Not required, but speeds up builds by storing container images in
+          # a GitHub package registry.
+          githubToken: ${{ github.token }}
+
+          # Set an output parameter `uname` for use in subsequent steps
+          run: |
+            docker build -f docker/Dockerfile.arm .
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - master
       - docker-images
+    tags:
+      - v*
 
 jobs:
   multi:
@@ -24,6 +26,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
+        name: Get smart tag
+        id: prepare
+        uses: Surgo/docker-smart-tag-action@v1
+        with:
+          docker_image: sylwekrapala/mspdebug
+      -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -31,5 +39,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm
           push: true
-          tags: |
-            sylwekrapala/mspdebug:latest
+          tags: ${{ steps.prepare.outputs.tag }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
         uses: Surgo/docker-smart-tag-action@v1
         with:
           docker_image: sylwekrapala/mspdebug
+          default_branch: ${{ github.event.repository.default_branch }}
       -
         name: Build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm/v6,linux/arm/v7
+          platforms: linux/amd64,linux/arm
           push: true
           tags: |
             user/app:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,24 +1,26 @@
 on: [push, pull_request]
 
 jobs:
-  armv7_job:
-    # The host should always be Linux
-    runs-on: ubuntu-18.04
-    name: Build on ubuntu-18.04 armv7
+  multi:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2.0.5
-        name: Run commands
-        id: runcmd
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
         with:
-          arch: armv7
-          distro: ubuntu18.04
-
-          # Not required, but speeds up builds by storing container images in
-          # a GitHub package registry.
-          githubToken: ${{ github.token }}
-
-          # Set an output parameter `uname` for use in subsequent steps
-          run: |
-            docker build -f docker/Dockerfile.arm .
-
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v6,linux/arm/v7
+          push: true
+          tags: |
+            user/app:latest
+            user/app:1.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - docker-images
 
 jobs:
   multi:
@@ -14,6 +18,12 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -22,5 +32,4 @@ jobs:
           platforms: linux/amd64,linux/arm
           push: true
           tags: |
-            user/app:latest
-            user/app:1.0.0
+            sylwekrapala/mspdebug:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM frolvlad/alpine-gcc as builder
-RUN apk add libusb-dev
+FROM gcc as builder
+RUN apt-get update && apt-get install -y libusb-dev
 RUN mkdir /src
 COPY . /src
 WORKDIR /src
 RUN make && ls
 
-FROM alpine:3
+FROM ubuntu
 COPY --from=builder /src/mspdebug /usr/bin/
 ENTRYPOINT ['/usr/bin/mspdebug']
 CMD ['--help']

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN make && ls
 FROM ubuntu:bionic
 RUN apt-get update && apt-get install -y libusb-0.1 libreadline7 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /src/mspdebug /usr/bin/
-ENTRYPOINT ['/usr/bin/mspdebug']
-CMD ['--help']
+ENTRYPOINT ["/usr/bin/mspdebug"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM gcc as builder
-RUN apt-get update && apt-get install -y libusb-dev
+RUN apt-get update && apt-get install -y libusb-dev && rm -rf /var/lib/apt/lists/*
 RUN mkdir /src
 COPY . /src
 WORKDIR /src
 RUN make && ls
 
-FROM ubuntu
+FROM ubuntu:bionic
+RUN apt-get update && apt-get install -y libusb-0.1 libreadline7 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /src/mspdebug /usr/bin/
 ENTRYPOINT ['/usr/bin/mspdebug']
 CMD ['--help']

--- a/docker/Dockerfile.arm
+++ b/docker/Dockerfile.arm
@@ -1,0 +1,11 @@
+FROM frolvlad/alpine-gcc as builder
+RUN apk add libusb-dev
+RUN mkdir /src
+COPY . /src
+WORKDIR /src
+RUN make && ls
+
+FROM alpine:3
+COPY --from=builder /src/mspdebug /usr/bin/
+ENTRYPOINT ['/usr/bin/mspdebug']
+CMD ['--help']


### PR DESCRIPTION
This PR adds CI to build docker images with mspdebug for multiplatform. I have tested it on arm and it worked. I think it could be an easy way to test mspdebug for people. 

You can test it under name `sylwekrapala/mspdebug:docer-image`
If you are interested in this there are some changes we need to do:
- [ ] create scerests `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`
- [ ] rename images
