### PR TITLE
elf32.c: Extract and flash INIT_ARRAY sections

### DIFF
--- a/formats/elf32.c
+++ b/formats/elf32.c
@@ -330,7 +330,8 @@ int elf32_extract(FILE *in, binfile_imgcb_t cb, void *user_data)
 	for (i = 0; i < info.file_ehdr.e_shnum; i++) {
 		Elf32_Shdr *s = &info.file_shdrs[i];
 
-		if (s->sh_type == SHT_PROGBITS && s->sh_flags & SHF_ALLOC &&
+		if ((s->sh_type == SHT_PROGBITS || s->sh_type == SHT_INIT_ARRAY) &&
+		    s->sh_flags & SHF_ALLOC &&
 		    feed_section(&info, in, s, cb, user_data) < 0) {
 			ret = -1;
 			break;


### PR DESCRIPTION
In newer Versions of `msp430-gcc` the init_array is moved to another section `.rodata2`:

```
--- /opt/ti/msp430/gcc-7.3.2/include/msp430fr6989.ld
+++ /opt/ti/msp430/msp430-gcc-9.2.0.50_linux64/include/msp430fr6989.ld
@@ -31,7 +31,7 @@
 /* ============================================================================ */
 /* This file supports MSP430FR6989 devices. */
-/* Version: 1.207 */
+/* Version: 1.208 */
 /* Default linker script, for normal executables */
 OUTPUT_ARCH(msp430)
@@ -192,17 +192,6 @@
     *(.rodata .rodata.* .gnu.linkonce.r.* .const .const:*)
     *(.rodata1)
     KEEP (*(.gcc_except_table)) *(.gcc_except_table.*)
-    PROVIDE (__preinit_array_start = .);
-    KEEP (*(.preinit_array))
-    PROVIDE (__preinit_array_end = .);
-    PROVIDE (__init_array_start = .);
-    KEEP (*(SORT(.init_array.*)))
-    KEEP (*(.init_array))
-    PROVIDE (__init_array_end = .);
-    PROVIDE (__fini_array_start = .);
-    KEEP (*(.fini_array))
-    KEEP (*(SORT(.fini_array.*)))
-    PROVIDE (__fini_array_end = .);
   } > ROM
   /* Note: This is a separate .rodata section for sections which are
@@ -211,6 +200,20 @@
      section as read-write.  */
   .rodata2 : 
   {
+    . = ALIGN(2);
+    PROVIDE (__preinit_array_start = .);
+    KEEP (*(.preinit_array))
+    PROVIDE (__preinit_array_end = .);
+    . = ALIGN(2);
+    PROVIDE (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array))
+    PROVIDE (__init_array_end = .);
+    . = ALIGN(2);
+    PROVIDE (__fini_array_start = .);
+    KEEP (*(.fini_array))
+    KEEP (*(SORT(.fini_array.*)))
+    PROVIDE (__fini_array_end = .);
     . = ALIGN(2);
     *(.eh_frame_hdr)
     KEEP (*(.eh_frame)) 
```

The type of this section is `INIT_ARRAY` and not `PROGBITS`:
```
  [ 6] .rodata           PROGBITS        00004400 000174 0006d8 00   A  0   0  2
  [ 7] .rodata2          INIT_ARRAY      00004ad8 000850 0000c6 04  WA  0   0  2
```

Using `mspdebug gdb` and `load` from within gdb will also flash the init_array, as expected. Using `mspdebug prog` will not flash the init_array, and programs depending on that will fail.

This path will simply also extract `INIT_ARRAY` sections for the `prog` command.