### PR TITLE
generalize x86-specific trap instruction

### DIFF
--- a/transport/mehfet_xport.c
+++ b/transport/mehfet_xport.c
@@ -155,7 +155,6 @@ static int tr_recv(transport_t tr_base, uint8_t *databuf, int max_len)
 		if (r <= 0) {
 			printc_err("mehfet transport: usb_bulk_read: %s\n",
 				   usb_strerror());
-			asm volatile("int3");
 			return -1;
 		}
 


### PR DESCRIPTION
This is a minor fix to the source to enable successful compilation on ARM-based machines. Using a patched `libmsp430.so`, I have tested that this works.

However, in my experience, `mspdebug` is only able to connect with the board a single time before it is unable to reconnect without unplugging the board and plugging it back in. This was tested under Parallels on Ubuntu for ARM running on an M1 Mac. Considering the `libmsp430.so` was also patched, it seems hard to tell where the problem lies, but during re-connection attempt, it just times out. There's no signs of a reset attempt from the board (no lights blink, current firmware doesn't pause visibly at all).

I don't know if this fix is a regression on x86-based machines, I did not test that (yet).