### PR TITLE
Add info to README about libusb 0.1 vs 1.0 and libusb-compat

### DIFF
--- a/README
+++ b/README
@@ -32,10 +32,16 @@ Compiling from source
 ---------------------
 
 Ensure that you have the necessary packages to compile programs that use
-libusb (on Debian or Ubuntu systems, you might need to do apt-get
-install libusb-dev | on Arch systems, you might need to do sudo 
-pacman -S libusb-compact). After that, unpack and compile the source code 
-with:
+libusb. Note that mspdebug depends on the libusb 0.1 API. If your distro
+provides libusb 1.0 instead of 0.1, you can probably use libusb-compat
+to provide backwards compatible usb.h and libusb.so files.
+
+On Debian or Ubuntu systems, you might need to do `apt-get install
+libusb-dev` | on Arch systems, you might need to do `sudo pacman -S
+libusb-compat` | on Gentoo systems, you might need to do
+`sudo emerge libusb-compat`.
+
+After that, unpack and compile the source code with:
 
     tar xvfz mspdebug-version.tar.gz
     cd mspdebug-version

--- a/README
+++ b/README
@@ -36,10 +36,10 @@ libusb. Note that mspdebug depends on the libusb 0.1 API. If your distro
 provides libusb 1.0 instead of 0.1, you can probably use libusb-compat
 to provide backwards compatible usb.h and libusb.so files.
 
-On Debian or Ubuntu systems, you might need to do `apt-get install
-libusb-dev` | on Arch systems, you might need to do `sudo pacman -S
-libusb-compat` | on Gentoo systems, you might need to do
-`sudo emerge libusb-compat`.
+On Debian or Ubuntu systems, you might need to do apt-get install
+libusb-dev | on Arch systems, you might need to do sudo pacman -S
+libusb-compat | on Gentoo systems, you might need to do sudo emerge
+libusb-compat.
 
 After that, unpack and compile the source code with:
 


### PR DESCRIPTION
Distros with recent versions of libusb (1.x) need to install libusb-compat to provide the legacy (0.1) API expected by mspdebug. After I figured out that libusb-compat was needed, I realized that was what was meant by the mention of libusb-compa**c**t on Arch systems (the typo fooled me the first time I read it). Hopefully it's clearer now.