### PR TITLE
.gitignore: ignore compile_commands.json and .cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ mspdebug
 mspdebug.exe
 inst/
 config.mk
+# temporary data for better code insight, e.g. when using bear and clangd
+/compile_commands.json
+/.cache


### PR DESCRIPTION
`compile_commands.json` (e.g. as generated with `bear -- make`) contains the exact commands used for building the binary including compiler flags such as include paths and warnings. It is useful for LLVM based tools for code completion / linting / ... such as clangd, as they then find the headers included. There is little reason in tracking this file, as it can be generated from the `Makefile` with `bear`.

`.cache` is a folder generated by `clangd` to speed up code completion, linting, etc.