### PR TITLE
ui/main.c: add --expect-id cmd line parameter

### DIFF
--- a/drivers/device.h
+++ b/drivers/device.h
@@ -82,6 +82,7 @@ struct device_args {
 	int			vcc_mv;
 	const char		*path;
 	const char		*forced_chip_id;
+	const char		*expect_chip_id;
 	const char		*requested_serial;
 	const char		*require_fwupdate;
 	const char		*bsl_entry_seq;


### PR DESCRIPTION
The new parameter is useful for integrating mspdebug into build systems that want to ensure that the firmware to flash is actually written to the matching hardware. This is helpful if the user mistyped the hardware to build for and flash, or confused similar looking hardware.