### PR TITLE
fix: correct libusb-compact to libusb-compat in README

### DIFF
--- a/README
+++ b/README
@@ -34,7 +34,7 @@ Compiling from source
 Ensure that you have the necessary packages to compile programs that use
 libusb (on Debian or Ubuntu systems, you might need to do apt-get
 install libusb-dev | on Arch systems, you might need to do sudo 
-pacman -S libusb-compact). After that, unpack and compile the source code 
+pacman -S libusb-compat). After that, unpack and compile the source code 
 with:
 
     tar xvfz mspdebug-version.tar.gz


### PR DESCRIPTION
## Summary
Fix a typo in the README: the Arch Linux package name is `libusb-compat`, not `libusb-compact` (which does not exist).

## Changes
- README line 37: `libusb-compact` → `libusb-compat`

## Testing
- Verified the correct package name against Arch Linux repositories
- The fix is a simple one-word correction with no code changes

Closes #141.